### PR TITLE
Update ZipStorer.cs

### DIFF
--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -192,7 +192,11 @@ namespace System.IO.Compression
 
             if (zip.ReadFileInfo())
                 return zip;
-
+            
+            /* prevent files/streams to be opened unused*/
+            if(!_leaveOpen)
+                Close();
+            
             throw new System.IO.InvalidDataException();
         }
         /// <summary>


### PR DESCRIPTION
Closing streams before throw InvalidDataException.
This prevents opened files if used with ZipStorer.Open(filename,...)